### PR TITLE
bugfix(TiltSensor):Device not waking for tilt interrupt

### DIFF
--- a/src/sensor.cpp
+++ b/src/sensor.cpp
@@ -177,15 +177,13 @@ float get_altitude(void)
 bool init_tilt_sensor(void)
 {
     pinMode(GPIO_INTERRUPT_TILT_SENSOR, INPUT_PULLUP);
-    attachInterrupt(digitalPinToInterrupt(GPIO_INTERRUPT_TILT_SENSOR), tilt_sensor_isr, CHANGE);
+    attachInterruptWakeup(GPIO_INTERRUPT_TILT_SENSOR, tilt_sensor_isr, CHANGE);
 
     return true;
 }
 
 void tilt_sensor_isr()
 {
-    detachInterrupt(digitalPinToInterrupt(GPIO_INTERRUPT_TILT_SENSOR));
-
     last_movement_time = millis(); //Noting the time when a movement occured.
 
     //if NOT already in movement_interval enabled mode...
@@ -195,8 +193,6 @@ void tilt_sensor_isr()
         //update alarm setting..
         use_movement_interval = true;
     }
-
-    attachInterrupt(digitalPinToInterrupt(GPIO_INTERRUPT_TILT_SENSOR), tilt_sensor_isr, CHANGE);
 }
 
 bool check_movement_timeout(void)

--- a/src/util.h
+++ b/src/util.h
@@ -27,6 +27,7 @@ void alarmMatch();
 void wake_device();
 bool get_status_log_sensor_data(void);
 void get_epoch_time_bytes(uint8_t *dataBuf);
+void attachInterruptWakeup(uint32_t pin, voidFuncPtr callback, uint32_t mode);
 
 void check_config();
 void get_settings(Config *ptrSettings);


### PR DESCRIPTION
Device does not wake up when there is a tilt sensor interrupt due to SAMD21 internal CLK source issues and it was fixed in this commit.

Dev Test: Build and test passed
![image](https://user-images.githubusercontent.com/76834143/132676570-d777adcf-153a-4b83-ad61-17a7aec39562.png)
