### PR TITLE
bugfix(BoostPower):Modem not powering on

### DIFF
--- a/src/modem.cpp
+++ b/src/modem.cpp
@@ -123,13 +123,28 @@ bool init_modem(void)
 bool init_modem_gpio(void)
 {
     pinMode(GPIO_OUTPUT_MODEM_PWR_EN, OUTPUT);
+    digitalWrite(GPIO_OUTPUT_MODEM_PWR_EN, HIGH);
+    os_delay_Ms(500);
 
     return true;
 }
 
 bool modem_turn_pwr(bool on_off_state)
 {
-    digitalWrite(GPIO_OUTPUT_MODEM_PWR_EN, on_off_state);
+    if(on_off_state)
+    {
+        digitalWrite(GPIO_OUTPUT_MODEM_PWR_EN, LOW);
+        os_delay_Ms(1000);
+        digitalWrite(GPIO_OUTPUT_MODEM_PWR_EN, HIGH);
+        os_delay_Ms(100);
+    }
+    else
+    {
+        digitalWrite(GPIO_OUTPUT_MODEM_PWR_EN, LOW);
+        os_delay_Ms(2500);
+        digitalWrite(GPIO_OUTPUT_MODEM_PWR_EN, HIGH);
+        os_delay_Ms(100);
+    }
 
     return true;
 }


### PR DESCRIPTION
Modem not turning on due to 5V boost converter power key controlling technique being wrong.

Dev Test: Build and Test passed
![image](https://user-images.githubusercontent.com/76834143/134854371-5ac2193f-bfca-47d8-b6ba-e6ee906b2b45.png)
